### PR TITLE
fix: telemetry payload

### DIFF
--- a/src/Hyphen.OpenFeature.Provider.Tests/HyphenUtilsTests.cs
+++ b/src/Hyphen.OpenFeature.Provider.Tests/HyphenUtilsTests.cs
@@ -51,7 +51,7 @@ namespace Hyphen.OpenFeature.Provider.Tests
             var result = HyphenUtils.ConvertJsonElementToValue(element);
 
             var list = result.AsList;
-            Assert.Equal("test", list[0].AsString!);
+            Assert.Equal("test", list![0].AsString!);
             Assert.Equal(123, list[1].AsInteger);
             Assert.True(list[2].AsBoolean);
         }
@@ -65,7 +65,7 @@ namespace Hyphen.OpenFeature.Provider.Tests
             var result = HyphenUtils.ConvertJsonElementToValue(element);
 
             var structure = result.AsStructure;
-            Assert.Equal("value1", structure["key1"].AsString!);
+            Assert.Equal("value1", structure!["key1"].AsString!);
             Assert.Equal(123, structure["key2"].AsInteger);
         }
 
@@ -148,5 +148,103 @@ namespace Hyphen.OpenFeature.Provider.Tests
 
             Assert.Null(result);
         }
+
+        [Fact]
+        public void ConvertObjectToValue_WithString_ReturnsValue()
+        {
+            var input = "test string";
+
+            var result = HyphenUtils.ConvertObjectToValue(input);
+
+            Assert.Equal(input, result.AsString);
+        }
+
+        [Fact]
+        public void ConvertObjectToValue_WithNumber_ReturnsValue()
+        {
+            var input = 123;
+
+            var result = HyphenUtils.ConvertObjectToValue(input);
+
+            Assert.Equal(input, result.AsInteger);
+        }
+
+        [Fact]
+        public void ConvertObjectToValue_WithBoolean_ReturnsValue()
+        {
+            var input = true;
+
+            var result = HyphenUtils.ConvertObjectToValue(input);
+
+            Assert.Equal(input, result.AsBoolean);
+        }
+
+        [Fact]
+        public void ConvertObjectToValue_WithList_ReturnsValue()
+        {
+            var input = new List<object> { "string", 123, true };
+
+            var result = HyphenUtils.ConvertObjectToValue(input);
+
+            var list = result.AsList;
+            Assert.Equal("string", list![0].AsString);
+            Assert.Equal(123, list[1].AsInteger);
+            Assert.Equal(true, list[2].AsBoolean);
+        }
+
+        [Fact]
+        public void ConvertObjectToValue_WithDictionary_ReturnsValue()
+        {
+            var input = new Dictionary<string, object>
+            {
+                { "key1", "value1" },
+                { "key2", 123 },
+                { "key3", true }
+            };
+
+            var result = HyphenUtils.ConvertObjectToValue(input);
+
+            var dict = result.AsStructure;
+            Assert.Equal("value1", dict!["key1"].AsString);
+            Assert.Equal(123, dict["key2"].AsInteger);
+            Assert.Equal(true, dict["key3"].AsBoolean);
+        }
+
+        [Fact]
+        public void ConvertObjectToValue_WithNull_ReturnsValue()
+        {
+            object? input = null;
+
+            var result = HyphenUtils.ConvertObjectToValue(input!);
+
+            Assert.True(result.IsNull);
+        }
+
+        [Fact]
+        public void ConvertObjectToValue_WithComplexObject_ReturnsValue()
+        {
+            var input = new
+            {
+                Name = "Test",
+                Age = 30,
+                IsActive = true,
+                Attributes = new Dictionary<string, object>
+                {
+                    { "Height", 180 },
+                    { "Weight", 75 }
+                }
+            };
+
+            var result = HyphenUtils.ConvertObjectToValue(input);
+
+            var structure = result.AsStructure;
+            Assert.Equal("Test", structure!["Name"].AsString);
+            Assert.Equal(30, structure["Age"].AsInteger);
+            Assert.Equal(true, structure["IsActive"].AsBoolean);
+            var attributes = structure["Attributes"].AsStructure;
+            Assert.Equal(180, attributes!["Height"].AsInteger);
+            Assert.Equal(75, attributes["Weight"].AsInteger);
+        }
+
     }
 }

--- a/src/Hyphen.OpenFeature.Provider.Tests/HyphenUtilsTests.cs
+++ b/src/Hyphen.OpenFeature.Provider.Tests/HyphenUtilsTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Text.Json;
+using System.Collections.Generic;
+using OpenFeature.Model;
+using Xunit;
+using Hyphen.OpenFeature.Provider;
+
+namespace Hyphen.OpenFeature.Provider.Tests
+{
+    public class HyphenUtilsTests
+    {
+        [Fact]
+        public void ConvertJsonElementToValue_String_ReturnsValue()
+        {
+            var json = "\"test\"";
+            var element = JsonDocument.Parse(json).RootElement;
+
+            var result = HyphenUtils.ConvertJsonElementToValue(element);
+
+            Assert.Equal("test", result.AsString);
+        }
+
+        [Fact]
+        public void ConvertJsonElementToValue_Number_ReturnsValue()
+        {
+            var json = "123";
+            var element = JsonDocument.Parse(json).RootElement;
+
+            var result = HyphenUtils.ConvertJsonElementToValue(element);
+
+            Assert.Equal(123, result.AsInteger);
+        }
+
+        [Fact]
+        public void ConvertJsonElementToValue_Boolean_ReturnsValue()
+        {
+            var json = "true";
+            var element = JsonDocument.Parse(json).RootElement;
+
+            var result = HyphenUtils.ConvertJsonElementToValue(element);
+
+            Assert.True(result.AsBoolean);
+        }
+
+        [Fact]
+        public void ConvertJsonElementToValue_Array_ReturnsValue()
+        {
+            var json = "[\"test\", 123, true]";
+            var element = JsonDocument.Parse(json).RootElement;
+
+            var result = HyphenUtils.ConvertJsonElementToValue(element);
+
+            var list = result.AsList;
+            Assert.Equal("test", list[0].AsString!);
+            Assert.Equal(123, list[1].AsInteger);
+            Assert.True(list[2].AsBoolean);
+        }
+
+        [Fact]
+        public void ConvertJsonElementToValue_Object_ReturnsValue()
+        {
+            var json = "{\"key1\": \"value1\", \"key2\": 123}";
+            var element = JsonDocument.Parse(json).RootElement;
+
+            var result = HyphenUtils.ConvertJsonElementToValue(element);
+
+            var structure = result.AsStructure;
+            Assert.Equal("value1", structure["key1"].AsString!);
+            Assert.Equal(123, structure["key2"].AsInteger);
+        }
+
+        [Fact]
+        public void ConvertJsonElementToValue_Null_ReturnsValue()
+        {
+            var json = "null";
+            var element = JsonDocument.Parse(json).RootElement;
+
+            var result = HyphenUtils.ConvertJsonElementToValue(element);
+
+            Assert.True(result.IsNull);
+        }
+
+        [Fact]
+        public void ConvertValueToObject_String_ReturnsObject()
+        {
+            var value = new Value("test");
+
+            var result = HyphenUtils.ConvertValueToObject(value);
+
+            Assert.Equal("test", result);
+        }
+
+        [Fact]
+        public void ConvertValueToObject_Number_ReturnsObject()
+        {
+            var value = new Value(123);
+
+            var result = HyphenUtils.ConvertValueToObject(value);
+            Assert.Equal(123, result);
+        }
+
+        [Fact]
+        public void ConvertValueToObject_Boolean_ReturnsObject()
+        {
+            var value = new Value(true);
+
+            var result = HyphenUtils.ConvertValueToObject(value);
+
+            Assert.True((bool)result!);
+        }
+
+        [Fact]
+        public void ConvertValueToObject_List_ReturnsObject()
+        {
+            var list = new List<Value> { new Value("test"), new Value(123), new Value(true) };
+            var value = new Value(list);
+
+            var result = HyphenUtils.ConvertValueToObject(value);
+
+            var resultList = (List<object?>)result!;
+            Assert.Equal("test", resultList[0]);
+            Assert.Equal(123, resultList[1]);
+            Assert.True((bool)resultList[2]!);
+        }
+
+        [Fact]
+        public void ConvertValueToObject_Structure_ReturnsObject()
+        {
+            var structure = Structure.Builder()
+                .Set("key1", new Value("value1"))
+                .Set("key2", new Value(123))
+                .Build();
+            var value = new Value(structure);
+
+            var result = HyphenUtils.ConvertValueToObject(value);
+
+            var resultDict = (Dictionary<string, object?>)result!;
+            Assert.Equal("value1", resultDict["key1"]);
+            Assert.Equal(123, resultDict["key2"]);
+        }
+
+        [Fact]
+        public void ConvertValueToObject_Null_ReturnsObject()
+        {
+            var value = new Value();
+
+            var result = HyphenUtils.ConvertValueToObject(value);
+
+            Assert.Null(result);
+        }
+    }
+}

--- a/src/Hyphen.OpenFeature.Provider/HyphenClient.cs
+++ b/src/Hyphen.OpenFeature.Provider/HyphenClient.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using OpenFeature.Model;
+using Hyphen.OpenFeature.Provider.Utils;
 
 namespace Hyphen.OpenFeature.Provider
 {
@@ -120,7 +121,7 @@ namespace Hyphen.OpenFeature.Provider
                 {
                     if (customAttributesStructure.TryGetValue(key, out var value))
                     {
-                        customAttributes[key] = value!.AsObject!;
+                        customAttributes[key] = ValueUtils.ConvertToNative(value);
                     }
                 }
             }
@@ -141,7 +142,7 @@ namespace Hyphen.OpenFeature.Provider
                 {
                     if (userCustomAttributesStructure.TryGetValue(key, out var value))
                     {
-                        userCustomAttributes[key] = value!.AsObject!;
+                        userCustomAttributes[key] = ValueUtils.ConvertToNative(value);
                     }
                 }
             }

--- a/src/Hyphen.OpenFeature.Provider/HyphenClient.cs
+++ b/src/Hyphen.OpenFeature.Provider/HyphenClient.cs
@@ -50,7 +50,7 @@ namespace Hyphen.OpenFeature.Provider
             {
                 return cachedResponse;
             }
-            HyphenEvaluationContext payload = BuildPayloadFromContext(context);
+            ContextPayload payload = BuildPayloadFromContext(context);
             var response = await TryUrls("/toggle/evaluate", payload);
             var evaluationResponse = JsonSerializer.Deserialize<EvaluationResponse>(response);
 
@@ -104,8 +104,7 @@ namespace Hyphen.OpenFeature.Provider
 
             return responseContent;
         }
-
-        public HyphenEvaluationContext BuildPayloadFromContext(EvaluationContext context)
+        public ContextPayload BuildPayloadFromContext(EvaluationContext context)
         {
             string? application = context.ContainsKey("Application") ? context.GetValue("Application").AsString : options.Application;
             string? environment = context.ContainsKey("Environment") ? context.GetValue("Environment").AsString : options.Environment;
@@ -125,7 +124,7 @@ namespace Hyphen.OpenFeature.Provider
                 }
             }
 
-            UserContext? user = userContext == null ? null : new UserContext
+            UserPayload? user = userContext == null ? null : new UserPayload
             {
                 id = userContext.ContainsKey("Id") ? userContext.GetValue("Id").AsString : null,
                 name = userContext.ContainsKey("Name") ? userContext.GetValue("Name").AsString : null,
@@ -149,7 +148,7 @@ namespace Hyphen.OpenFeature.Provider
             if (user != null)
                 user.customAttributes = userCustomAttributes;
 
-            HyphenEvaluationContext payload = new HyphenEvaluationContext
+            ContextPayload payload = new ContextPayload
             {
                 targetingKey = context.TargetingKey!,
                 ipAddress = ipAddress,
@@ -165,7 +164,7 @@ namespace Hyphen.OpenFeature.Provider
 
     public class TelemetryPayload
     {
-        public required HyphenEvaluationContext context { get; set; }
+        public required ContextPayload context { get; set; }
         public required TelemetryData data { get; set; }
     }
 
@@ -186,5 +185,23 @@ namespace Hyphen.OpenFeature.Provider
         public required string type { get; set; }
         public string? reason { get; set; }
         public string? errorMessage { get; set; }
+    }
+
+    public class ContextPayload
+    {
+        public required string targetingKey { get; set; }
+        public required string application { get; set; }
+        public required string environment { get; set; }
+        public string? ipAddress { get; set; }
+        public Dictionary<string, object>? customAttributes { get; set; }
+        public UserPayload? user { get; set; }
+    }
+
+    public class UserPayload
+    {
+        public string? id { get; set; }
+        public string? email { get; set; }
+        public string? name { get; set; }
+        public Dictionary<string, object>? customAttributes { get; set; }
     }
 }

--- a/src/Hyphen.OpenFeature.Provider/HyphenClient.cs
+++ b/src/Hyphen.OpenFeature.Provider/HyphenClient.cs
@@ -1,7 +1,6 @@
 using System.Text;
 using System.Text.Json;
 using OpenFeature.Model;
-using Hyphen.OpenFeature.Provider.Utils;
 
 namespace Hyphen.OpenFeature.Provider
 {
@@ -121,7 +120,7 @@ namespace Hyphen.OpenFeature.Provider
                 {
                     if (customAttributesStructure.TryGetValue(key, out var value))
                     {
-                        customAttributes[key] = ValueUtils.ConvertToNative(value);
+                        customAttributes[key] = HyphenUtils.ConvertValueToObject(value!)!;
                     }
                 }
             }
@@ -142,7 +141,7 @@ namespace Hyphen.OpenFeature.Provider
                 {
                     if (userCustomAttributesStructure.TryGetValue(key, out var value))
                     {
-                        userCustomAttributes[key] = ValueUtils.ConvertToNative(value);
+                        userCustomAttributes[key] = HyphenUtils.ConvertValueToObject(value!)!;
                     }
                 }
             }

--- a/src/Hyphen.OpenFeature.Provider/HyphenEvaluationContext.cs
+++ b/src/Hyphen.OpenFeature.Provider/HyphenEvaluationContext.cs
@@ -1,36 +1,56 @@
+using OpenFeature.Model;
+
 namespace Hyphen.OpenFeature.Provider
 {
     public class HyphenEvaluationContext
     {
         /// <summary>
-        /// The key used for caching the evaluation response.
+        /// The unique identifier for the user or entity being evaluated.
         /// </summary>
-        public required string targetingKey { get; set; }
-
-        /// <summary>
-        /// The application name or ID for the current evaluation.
-        /// </summary>
-        public required string application { get; set; }
-
-        /// <summary>
-        /// The environment identifier for the Hyphen project.
-        /// </summary>
-        public required string environment { get; set; }
-
+        public string? TargetingKey { get; init; }
         /// <summary>
         /// The IP address of the user making the request.
         /// </summary>
-        public string? ipAddress { get; set; }
+        public string? IpAddress { get; init; }
 
         /// <summary>
         /// Custom attributes for additional contextual information.
         /// </summary>
-        public Dictionary<string, object>? customAttributes { get; set; }
+        public Dictionary<string, object>? CustomAttributes { get; init; }
 
         /// <summary>
         /// An object containing user-specific information for the evaluation.
         /// </summary>
-        public UserContext? user { get; set; }
+        public UserContext? User { get; init; }
+
+        /// <summary>
+        /// Creates an instance of <see cref="EvaluationContext"/> with the specified properties.
+        /// </summary>
+        public EvaluationContext GetEvaluationContext()
+        {
+            EvaluationContextBuilder builder = EvaluationContext.Builder();
+            if (!string.IsNullOrEmpty(IpAddress))
+            {
+                builder.Set("IpAddress", IpAddress);
+            }
+            if (CustomAttributes != null)
+            {
+                builder.Set("CustomAttributes", HyphenUtils.ConvertObjectToValue(CustomAttributes));
+            }
+            if (User != null)
+            {
+                builder.Set("User", HyphenUtils.ConvertObjectToValue(User));
+                if (User.Id != null)
+                {
+                    builder.SetTargetingKey(User.Id.ToString());
+                }
+            }
+            if (!string.IsNullOrEmpty(TargetingKey))
+            {
+                builder.SetTargetingKey(TargetingKey);
+            }
+            return builder.Build();
+        }
     }
 
     public class UserContext
@@ -38,21 +58,21 @@ namespace Hyphen.OpenFeature.Provider
         /// <summary>
         /// The unique identifier of the user.
         /// </summary>
-        public string? id { get; set; }
+        public string? Id { get; set; }
 
         /// <summary>
         /// The email address of the user.
         /// </summary>
-        public string? email { get; set; }
+        public string? Email { get; set; }
 
         /// <summary>
         /// The name of the user.
         /// </summary>
-        public string? name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Custom attributes specific to the user.
         /// </summary>
-        public Dictionary<string, object>? customAttributes { get; set; }
+        public Dictionary<string, object>? CustomAttributes { get; set; }
     }
 }

--- a/src/Hyphen.OpenFeature.Provider/HyphenHook.cs
+++ b/src/Hyphen.OpenFeature.Provider/HyphenHook.cs
@@ -13,7 +13,7 @@ namespace Hyphen.OpenFeature.Provider
                 return;
             }
             HyphenClient hyphenClient = new(publicKey, options);
-            HyphenEvaluationContext payloadFromContext = hyphenClient.BuildPayloadFromContext(context.EvaluationContext);
+            ContextPayload payloadFromContext = hyphenClient.BuildPayloadFromContext(context.EvaluationContext);
             string type = details.FlagMetadata?.GetString("type") ?? details.Value!.GetType().Name;
 
             Evaluation evaluationDetails = new Evaluation
@@ -23,7 +23,7 @@ namespace Hyphen.OpenFeature.Provider
                 type = type,
                 reason = details.Reason,
             };
-            HyphenEvaluationContext contextData = new HyphenEvaluationContext
+            ContextPayload contextData = new ContextPayload
             {
                 targetingKey = payloadFromContext.targetingKey,
                 application = payloadFromContext.application,

--- a/src/Hyphen.OpenFeature.Provider/HyphenHook.cs
+++ b/src/Hyphen.OpenFeature.Provider/HyphenHook.cs
@@ -1,5 +1,7 @@
 ﻿using OpenFeature.Model;
 using OpenFeature;
+using System.Text.Json;
+using Hyphen.OpenFeature.Provider.Utils;
 
 namespace Hyphen.OpenFeature.Provider
 {
@@ -18,7 +20,7 @@ namespace Hyphen.OpenFeature.Provider
             Evaluation evaluationDetails = new Evaluation
             {
                 key = details.FlagKey,
-                value = details.Value!,
+                value = details.Value! is Value val ? ValueUtils.ConvertToNative(val) : details.Value,
                 type = type,
                 reason = details.Reason,
             };

--- a/src/Hyphen.OpenFeature.Provider/HyphenHook.cs
+++ b/src/Hyphen.OpenFeature.Provider/HyphenHook.cs
@@ -1,7 +1,6 @@
 ﻿using OpenFeature.Model;
 using OpenFeature;
 using System.Text.Json;
-using Hyphen.OpenFeature.Provider.Utils;
 
 namespace Hyphen.OpenFeature.Provider
 {
@@ -20,7 +19,7 @@ namespace Hyphen.OpenFeature.Provider
             Evaluation evaluationDetails = new Evaluation
             {
                 key = details.FlagKey,
-                value = details.Value! is Value val ? ValueUtils.ConvertToNative(val) : details.Value,
+                value = details.Value is Value val ? HyphenUtils.ConvertValueToObject(val)! : details.Value!,
                 type = type,
                 reason = details.Reason,
             };

--- a/src/Hyphen.OpenFeature.Provider/HyphenProvider.cs
+++ b/src/Hyphen.OpenFeature.Provider/HyphenProvider.cs
@@ -146,7 +146,6 @@ namespace Hyphen.OpenFeature.Provider
                 Evaluation evaluation = await GetEvaluation<double>(flagKey, context);
                 if (evaluation.type != "number")
                     return new ResolutionDetails<double>(flagKey, defaultValue, ErrorType.TypeMismatch);
-
                 ImmutableMetadata metadata = GetMetadata(evaluation.type);
                 return new ResolutionDetails<double>(flagKey, Convert.ToDouble(evaluation.value), ErrorType.None, evaluation.reason, null, null, metadata);
             }
@@ -217,7 +216,6 @@ namespace Hyphen.OpenFeature.Provider
             if (!response.toggles.TryGetValue(flagKey, out Evaluation? evaluation))
                 throw new KeyNotFoundException($"Flag {flagKey} not found");
 
-
             T value;
             if (evaluation.value != null && evaluation.type != "object")
             {
@@ -227,7 +225,7 @@ namespace Hyphen.OpenFeature.Provider
                 }
                 else
                 {
-                    value = (T)evaluation.value;
+                    value = (T)Convert.ChangeType(evaluation.value, typeof(T));
                 }
                 evaluation.value = value;
             }

--- a/src/Hyphen.OpenFeature.Provider/HyphenProvider.cs
+++ b/src/Hyphen.OpenFeature.Provider/HyphenProvider.cs
@@ -4,7 +4,6 @@ using OpenFeature.Constant;
 using OpenFeature;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using Hyphen.OpenFeature.Provider.Utils;
 
 namespace Hyphen.OpenFeature.Provider
 {
@@ -184,7 +183,7 @@ namespace Hyphen.OpenFeature.Provider
                                 var structure = Structure.Builder();
                                 foreach (var property in parsedJson.EnumerateObject())
                                 {
-                                    structure.Set(property.Name, ValueUtils.ConvertJsonElementToValue(property.Value));
+                                    structure.Set(property.Name, HyphenUtils.ConvertJsonElementToValue(property.Value));
                                 }
 
                                 return new ResolutionDetails<Value>(flagKey, new Value(structure.Build()), ErrorType.None, evaluation.reason, null, null, metadata);

--- a/src/Hyphen.OpenFeature.Provider/HyphenProvider.cs
+++ b/src/Hyphen.OpenFeature.Provider/HyphenProvider.cs
@@ -4,6 +4,7 @@ using OpenFeature.Constant;
 using OpenFeature;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Hyphen.OpenFeature.Provider.Utils;
 
 namespace Hyphen.OpenFeature.Provider
 {
@@ -184,7 +185,7 @@ namespace Hyphen.OpenFeature.Provider
                                 var structure = Structure.Builder();
                                 foreach (var property in parsedJson.EnumerateObject())
                                 {
-                                    structure.Set(property.Name, property.Value.GetRawText());
+                                    structure.Set(property.Name, ValueUtils.ConvertJsonElementToValue(property.Value));
                                 }
 
                                 return new ResolutionDetails<Value>(flagKey, new Value(structure.Build()), ErrorType.None, evaluation.reason, null, null, metadata);
@@ -194,9 +195,9 @@ namespace Hyphen.OpenFeature.Provider
                                 return new ResolutionDetails<Value>(flagKey, defaultValue, ErrorType.TypeMismatch);
                             }
                         }
-                        catch
+                        catch (Exception ex)
                         {
-                            return new ResolutionDetails<Value>(flagKey, defaultValue, ErrorType.ParseError);
+                            return new ResolutionDetails<Value>(flagKey, defaultValue, ErrorType.ParseError, null, null, ex.Message);
                         }
                     }
                 }

--- a/src/Hyphen.OpenFeature.Provider/HyphenProvider.cs
+++ b/src/Hyphen.OpenFeature.Provider/HyphenProvider.cs
@@ -233,15 +233,8 @@ namespace Hyphen.OpenFeature.Provider
 
         private string GetTargetingKey(EvaluationContext context)
         {
-            Structure? userContext = context.ContainsKey("User") ? context.GetValue("User").AsStructure : null;
-            var user = userContext == null ? null : new
-            {
-                Id = userContext.ContainsKey("Id") ? userContext.GetValue("Id").AsString : null,
-            };
             if (!string.IsNullOrEmpty(context.TargetingKey))
                 return context.TargetingKey;
-            if (user != null && !string.IsNullOrEmpty(user.Id))
-                return user.Id;
 
             return $"{_options.Application}-{_options.Environment}-{Guid.NewGuid().ToString("N")[..8]}";
         }

--- a/src/Hyphen.OpenFeature.Provider/HyphenUtils.cs
+++ b/src/Hyphen.OpenFeature.Provider/HyphenUtils.cs
@@ -93,7 +93,8 @@ namespace Hyphen.OpenFeature.Provider
                 var json = JsonSerializer.Serialize(obj);
                 var jsonElement = JsonSerializer.Deserialize<JsonElement>(json);
                 return ConvertJsonElementToValue(jsonElement);
-            } catch (Exception ex)
+            }
+            catch (Exception ex)
             {
                 throw new ArgumentException($"Failed to convert object to Value: {ex.Message}", ex);
             }

--- a/src/Hyphen.OpenFeature.Provider/HyphenUtils.cs
+++ b/src/Hyphen.OpenFeature.Provider/HyphenUtils.cs
@@ -60,7 +60,11 @@ namespace Hyphen.OpenFeature.Provider
         public static object? ConvertValueToObject(Value value)
         {
             if (value.IsBoolean) return value.AsBoolean!;
-            if (value.IsNumber) return (value.AsDouble ?? value.AsInteger)!;
+            if (value.IsNumber)
+            {
+                if (value.AsInteger.HasValue) return value.AsInteger.Value;
+                if (value.AsDouble.HasValue) return value.AsDouble.Value;
+            }
             if (value.IsList) return value.AsList!.Select(ConvertValueToObject).ToList();
             if (value.IsStructure)
             {

--- a/src/Hyphen.OpenFeature.Provider/HyphenUtils.cs
+++ b/src/Hyphen.OpenFeature.Provider/HyphenUtils.cs
@@ -79,5 +79,24 @@ namespace Hyphen.OpenFeature.Provider
             if (value.IsString) return value.AsString!;
             return value.AsObject!;
         }
+
+        /// <summary>
+        /// Converts an object to a Value object.
+        /// </summary>
+        /// <param name="obj">The object to convert.</param>
+        /// <returns>A Value object representing the object.</returns>
+        /// <exception cref="ArgumentException">Thrown when the object cannot be converted to a Value.</exception>
+        public static Value ConvertObjectToValue(object obj)
+        {
+            try
+            {
+                var json = JsonSerializer.Serialize(obj);
+                var jsonElement = JsonSerializer.Deserialize<JsonElement>(json);
+                return ConvertJsonElementToValue(jsonElement);
+            } catch (Exception ex)
+            {
+                throw new ArgumentException($"Failed to convert object to Value: {ex.Message}", ex);
+            }
+        }
     }
 }

--- a/src/Hyphen.OpenFeature.Provider/Utils/ValueUtils.cs
+++ b/src/Hyphen.OpenFeature.Provider/Utils/ValueUtils.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Linq;
+using System.Text.Json;
+using System.Collections.Generic;
+using OpenFeature.Model;
+
+namespace Hyphen.OpenFeature.Provider.Utils
+{
+    public static class ValueUtils
+    {
+        public static Value ConvertJsonElementToValue(JsonElement element)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.String:
+                    return new Value(element.GetString());
+
+                case JsonValueKind.Number:
+                    if (element.TryGetInt64(out long longValue))
+                        return new Value(longValue);
+                    return new Value(element.GetDouble());
+
+                case JsonValueKind.True:
+                case JsonValueKind.False:
+                    return new Value(element.GetBoolean());
+
+                case JsonValueKind.Array:
+                    var list = element.EnumerateArray()
+                        .Select(ConvertJsonElementToValue)
+                        .ToList();
+                    return new Value(list);
+
+                case JsonValueKind.Object:
+                    var structure = Structure.Builder();
+                    foreach (var prop in element.EnumerateObject())
+                    {
+                        structure.Set(prop.Name, ConvertJsonElementToValue(prop.Value));
+                    }
+                    return new Value(structure.Build());
+
+                case JsonValueKind.Null:
+                    return new Value((string?)null);
+
+                default:
+                    throw new ArgumentException($"Unsupported JSON value kind: {element.ValueKind}");
+            }
+        }
+
+        public static object ConvertToNative(Value value)
+        {
+            if (value.IsBoolean) return value.AsBoolean;
+            if (value.IsNumber) return value.AsDouble ?? value.AsInteger;
+            if (value.IsList) return value.AsList?.Select(ConvertToNative).ToList();
+            if (value.IsStructure)
+            {
+                var dict = new Dictionary<string, object>();
+                foreach (var item in value.AsStructure)
+                {
+                    dict[item.Key] = ConvertToNative(item.Value);
+                }
+                return dict;
+            }
+            if (value.IsNull) return null;
+            if (value.IsString) return value.AsString;
+            return value.AsObject;
+        }
+    }
+}


### PR DESCRIPTION
The initial issue was that `CustomAttributes`, being a `Dictionary<string, object>`, allowed deep nesting, which resulted in storing data in the database like:
```
{
  "Key": "omega",
  "Value": {
    "AsBoolean": null,
    "AsDateTime": null,
    "AsDouble": null,
    "AsInteger": null,
    "AsList": null,
    "AsObject": "\"test\"",
    "AsString": "\"test\"",
    "AsStructure": null,
    "IsBoolean": false,
    "IsDateTime": false,
    "IsList": false,
    "IsNull": false,
    "IsNumber": false,
    "IsString": true,
    "IsStructure": false
  }
}

```
when it should have been stored as:
```
{
  "omega": "test"
}

```
## Changes Implemented
* Created a parser called `ConvertValueToObject` that converts Value types into primitive objects to be sent as JSON in the evaluate and telemetry payloads.

* Added a parser called `ConvertJsonElementToValue`, which processes the incoming JSON from the API and converts it into Value types for internal use within the provider.

* Introduced the `HyphenEvaluationContext` class, allowing users to generate the context used internally, including the available fields, and to construct the context for evaluations.

* This ensures that the context is properly structured, improving data consistency.

Really large loom with end-to-end tests (Updated)
https://www.loom.com/share/7619337bb5ac4f4a9fcd51df55a270e0?sid=d77a81bd-3ee5-4c17-9d32-099a7ef35d31